### PR TITLE
Feat￤categorize

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
 				"--user-data-dir=${workspaceFolder}/.vscode-chrome-debug"
 			],
 			"runtimeExecutable": "stable",
-			"webRoot": "${workspaceFolder}"
+			"webRoot": "${workspaceFolder}",
+			"file": "${workspaceFolder}/test/index.html"
 		}
 	]
 }

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -16,6 +16,9 @@ export default defineManifest({
   },
   content_scripts: [{
     js: ['src/content/main.ts'],
-    matches: ['https://*/*'],
+    matches: [
+      'https://*/*',
+      'file:///*',
+    ],
   }],
 })

--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -1,1 +1,7 @@
+import { categorize } from "../logic/categorize";
+
 console.log('[CRXJS] Hello world from content script!')
+
+Array.from(document.getElementsByTagName("button")).forEach(element => {
+	console.log('Button categorized:', `${element.id}`, categorize(getComputedStyle(element)));
+});

--- a/src/logic/categorize.ts
+++ b/src/logic/categorize.ts
@@ -1,0 +1,38 @@
+// スタイルをもとにカテゴライズ。
+// トランジション時間が 0.2 秒未満かつボックスシャドウがない場合は Flat、
+// トランジション時間が 0.2 秒未満かつボックスシャドウがある場合は Snappy。
+// トランジション時間が 0.2 秒以上なら Smooth-fade とする。
+export function categorize(input: CSSStyleDeclaration): string {
+	const transProps = input.transitionProperty;
+	const transDur = input.transitionDuration;
+	const transDurationSec = parseTransitionDuration(transDur);
+	const hasShadow = input.boxShadow && input.boxShadow !== "none";
+
+	if (!transProps || transDurationSec < 0.2) {
+		if (hasShadow) {
+			return "Snappy";
+		} else {
+			return "Flat";
+		}
+	} else if (transDurationSec >= 0.2) {
+		return "Smooth-fade";
+	}
+
+	return "Flat";
+}
+
+// トランジションDurationを秒にパースする補助
+function parseTransitionDuration(value: string): number {
+	if (!value) return 0;
+	// 例: "0.3s, 0.1s" の場合、最大値をとる
+	const parts = value.split(",").map(s => s.trim());
+	let max = 0;
+	parts.forEach(p => {
+		if (p.endsWith("ms")) {
+			max = Math.max(max, parseFloat(p) / 1000);
+		} else if (p.endsWith("s")) {
+			max = Math.max(max, parseFloat(p));
+		}
+	});
+	return max;
+}

--- a/src/logic/categorize.ts
+++ b/src/logic/categorize.ts
@@ -8,7 +8,7 @@ export function categorize(input: CSSStyleDeclaration): string {
 	const transDurationSec = parseTransitionDuration(transDur);
 	const hasShadow = input.boxShadow && input.boxShadow !== "none";
 
-	if (!transProps || transDurationSec < 0.2) {
+	if (transProps === 'none' || transDurationSec < 0.2) {
 		if (hasShadow) {
 			return "Snappy";
 		} else {

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+
+		<style>
+			#greenButton {
+				background-color: #4CAF50; /* Green */
+				border: none;
+				color: white;
+				padding: 15px 32px;
+				text-align: center;
+				text-decoration: none;
+				display: inline-block;
+				font-size: 16px;
+				margin: 4px 2px;
+				cursor: pointer;
+
+				transition: all 0.3s ease;
+
+				&:hover {
+					background-color: #45a049; /* Darker green on hover */
+					transform: translate(0, 2px); /* Move down on hover */
+				}
+			}
+
+			#grayButton {
+				background-color: rgb(224, 224, 224);
+				border: none;
+				color: black;
+				padding: 8px 16px;
+				text-align: center;
+				text-decoration: none;
+				display: inline-block;
+				font-size: 16px;
+				margin: 4px 2px;
+				cursor: pointer;
+				border-radius: 99px;
+
+				transition: all 0.15s ease;
+
+				&:hover {
+					background-color: #d4d4d4; /* Darker gray on hover */
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<button id="greenButton">Click Me!</button>
+		<button id="grayButton">Gray Button</button>
+	</body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ import { name, version } from './package.json'
 export default defineConfig({
   resolve: {
     alias: {
-      '@': `${path.resolve(__dirname, 'src')}`,
+      '~/*': `${path.resolve(__dirname, 'src/*')}`,
     },
   },
   plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '~': `${path.resolve(__dirname, 'src')}`,
+      '@': `${path.resolve(__dirname, 'src')}`,
     },
   },
   plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ import { name, version } from './package.json'
 export default defineConfig({
   resolve: {
     alias: {
-      '~/*': `${path.resolve(__dirname, 'src/*')}`,
+      '~': `${path.resolve(__dirname, 'src')}`,
     },
   },
   plugins: [


### PR DESCRIPTION
#3 を参照。
ただし一部の要件を変更しています。

- CSS プロパティを受け取り、`Snappy`、`Flat`、`Smooth-Fade` の三種類にカテゴライズする関数を実装。
- ブラウザで拡張機能を追加したあと、ファイル `test/index.html` を開くとコンソールにカテゴライズ結果を表示します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new function to categorize button styles based on their visual properties.
  * Added logging of button categorizations for all buttons on the page.
  * Included a sample HTML page with styled buttons for testing and demonstration.

* **Improvements**
  * Content scripts now support running on local file URLs in addition to HTTPS pages.
  * Updated project configuration to use a new alias prefix for source imports.

* **Chores**
  * Enhanced VSCode launch settings for easier Chrome debugging of the test page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->